### PR TITLE
Ajout du plugin sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ bootsnap-compile-cache/
 !/plugins/styleguide
 !/plugins/discourse-local-dates
 !/plugins/discourse-solved
+!/plugins/discourse-sentry
 /plugins/*/auto_generated/
 
 /spec/fixtures/plugins/my_plugin/auto_generated

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "plugins/discourse-solved"]
 	path = plugins/discourse-solved
-	url = git@github.com:discourse/discourse-solved.git
+	url = https://github.com/discourse/discourse-solved.git
 [submodule "plugins/discourse-sentry"]
 	path = plugins/discourse-sentry
-	url = git@github.com:debtcollective/discourse-sentry.git
+	url = https://github.com/debtcollective/discourse-sentry.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "plugins/discourse-solved"]
 	path = plugins/discourse-solved
 	url = git@github.com:discourse/discourse-solved.git
+[submodule "plugins/discourse-sentry"]
+	path = plugins/discourse-sentry
+	url = git@github.com:debtcollective/discourse-sentry.git


### PR DESCRIPTION
Ajout du [plugin sentry](https://github.com/debtcollective/discourse-sentry) pour discourse.

On a 2 options pour ajouter un plugin:
 - l’ajouter dans `plugins`
 - ajouter un hook post-déploiement coté clever-cloud pour cloner le plugin.

Après discussion, on est parti sur l’approche par sous-modules, afin d’avoir un controle plus fin des montées de version.