### PR TITLE
Ajout du plugin discourse-solved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ bootsnap-compile-cache/
 !/plugins/discourse-presence
 !/plugins/styleguide
 !/plugins/discourse-local-dates
+!/plugins/discourse-solved
 /plugins/*/auto_generated/
 
 /spec/fixtures/plugins/my_plugin/auto_generated

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/discourse-solved"]
+	path = plugins/discourse-solved
+	url = git@github.com:discourse/discourse-solved.git


### PR DESCRIPTION
Le plugin [discourse-solved](https://meta.discourse.org/t/discourse-solved-accepted-answer-plugin/30155) est la solution standard pour gérer les questions répondues. C’est conçu par l’équipe discourse et cela semble être la mieux intégrée ou maintenue, parmi les quelques options disponibles :

 - les demandeurs et les admins peuvent marquer une question comme répondue
 - on peut voir la réponse sous la question initiale
 - dans la liste des réponses, une checkbox (discrète) indique que la question est répondue
 - on peut filtrer dans la recherche par question répondue.

# Aperçu d’une réponse sous la réponse initiale

![Capture d’écran de 2020-11-09 15-07-13](https://user-images.githubusercontent.com/1223316/98551202-54a15080-229d-11eb-8b3f-046ab0fff0a7.png)

# Élement de liste avec message répondu

![Capture d’écran de 2020-11-09 14-58-07](https://user-images.githubusercontent.com/1223316/98550733-c200b180-229c-11eb-8dd8-665460828d94.png)

# Filtre de recherche (dans les options avancées aujourd’hui)

![Capture d’écran de 2020-11-09 14-45-45](https://user-images.githubusercontent.com/1223316/98550714-bd3bfd80-229c-11eb-94f3-a3bec6bd078f.png)

Ceci étant dit, marquer un message comme répondu est difficile (il faut cliquer sur "…" sous le message, puis sur "solution" parmi les nombreuses options. J’ai eu du mal à trouver alors que je savais ce que je voulais faire…). Il faudra probablement travailler cette zone pour la rendre plus simple.

![Capture d’écran de 2020-11-09 14-46-12](https://user-images.githubusercontent.com/1223316/98550727-c036ee00-229c-11eb-99d6-5d172444ab3e.png)