### PR TITLE
Fix assets:precompile deployment task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ down:
 	d/shutdown_dev
 
 bash:
-	docker exec -it discourse_dev bash
+	docker exec -it -u discourse -w /src discourse_dev /bin/bash
 
 update_discourse:
 	git fetch upstream

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,7 +14,9 @@ Discourse::Application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.public_file_server.enabled = GlobalSetting.serve_static_assets || false
 
-  config.assets.js_compressor = :uglifier
+  # Fix for Uglifier::Error: … To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
+  # https://stackoverflow.com/questions/41531527/cant-precompile-production-assets-when-using-es6#49528271
+  config.assets.js_compressor = Uglifier.new(harmony: true)
 
   # stuff should be pre-compiled
   config.assets.compile = false


### PR DESCRIPTION
An attempt to fix the deployment. `assets:precompile` works locally but not on staging.

Probably not the best way to fix this issue, but it should be OK after that, `assets:precompile` is the last complicated deployment step.