### PR TITLE
fix assets:precompile using harmony correctly

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,9 +14,7 @@ Discourse::Application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.public_file_server.enabled = GlobalSetting.serve_static_assets || false
 
-  # Fix for Uglifier::Error: … To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
-  # https://stackoverflow.com/questions/41531527/cant-precompile-production-assets-when-using-es6#49528271
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :uglifier
 
   # stuff should be pre-compiled
   config.assets.compile = false

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -115,6 +115,7 @@ def compress_ruby(from, to)
   data = File.read("#{assets_path}/#{from}")
 
   uglified, map = Uglifier.new(comments: :none,
+                               harmony: true,
                                source_map: {
                                  filename: File.basename(from),
                                  output_filename: File.basename(to)


### PR DESCRIPTION
My previous fix in order to update discourse didn’t work, and couldnt work. When I tried locally I didn’t set the env correctly, so it broke during deployment.

I see [3 solutions](https://meta.discourse.org/t/uglifier-error-during-assets-precompile/96970/2) to the assets compilation being broken (`Uglifier::Error: Unexpected token: … To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true)`) with our custom install:

 - setting up `uglify-js` to a known, valid version globally. This is probably [not desirable](https://nodejs.dev/learn/npm-global-or-local-packages):
> In general, all packages should be installed locally.
  - updating `uglify-js` locally. I’m afraid updating dependencies it’s going to mess with other dependency update in the future, merge will be complicated
 - adding this `harmony: true` and hope for the best.

I’m trying the last one here.