### PR TITLE
Mise à jour du plugin discourse-solved

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "plugins/discourse-solved"]
 	path = plugins/discourse-solved
 	url = https://github.com/discourse/discourse-solved.git
+	branch = main
 [submodule "plugins/discourse-sentry"]
 	path = plugins/discourse-sentry
 	url = https://github.com/debtcollective/discourse-sentry.git


### PR DESCRIPTION
Montée de version des sous modules:
 - RAS chez [discourse-sentry](https://github.com/debtcollective/discourse-sentry)
 - les changements récents dans [discourse-solved](https://github.com/discourse/discourse-solved) corrigent les problèmes  d’affichage constaté. À noter que les petits filous ont changé la branche principale (master -> main) ce qui a un peu perturbé git, qui ne comprenait plus de quoi on parlait.
 
À noter pour les fois suivantes que:
 - mettre à jour les plugins se fait via `git submodule foreach git pull origin`
 - un fichier `.gitmodules` contient les références des sous-modules
 - `git submodule` permet de savoir où on en est:
```
git submodule
 990ec739294c8d0431b79f49c8a0d04349a823c5 plugins/discourse-sentry (heads/master)
 3048576064f5d8ad64b652248c34edd550719664 plugins/discourse-solved (heads/master)

```